### PR TITLE
#19 | Handle wallet deeplinks on mobile

### DIFF
--- a/src/features/bridge/ui/AccountModal.tsx
+++ b/src/features/bridge/ui/AccountModal.tsx
@@ -14,7 +14,7 @@ import {Box, SxProps} from '@/core/ui/system';
 import {Tabs} from '@/core/ui/Tabs';
 import {WalletIcon} from '@/core/ui/WalletIcon';
 import {formatAddress} from '@/core/utils/formatAddress';
-import { isMobile } from '@/core/utils/platform';
+import {isMobile} from '@/core/utils/platform';
 
 import {TransactionItem} from './TransactionItem';
 

--- a/src/features/core/utils/platform.ts
+++ b/src/features/core/utils/platform.ts
@@ -1,0 +1,4 @@
+export function isMobile() {
+    const mobileRegex = /Android|webOS|iPhone|iPad|iPod|BlackBerry|BB|PlayBook|IEMobile|Windows Phone|Kindle|Silk|Opera Mini/i;
+    return mobileRegex.test(navigator.userAgent);
+}


### PR DESCRIPTION
# Fixes #19

## Description
This PR updates how the app handles login links, especially on mobile. This includes:
1. removing brave altogether, to be fixed in #20 
2. on mobile, changing login button language to 'Continue on [wallet name]' and opening the selected wallet app when tapped
3. hiding Core wallet entirely on mobile, as they have no deeplink capability

note: at the time of writing, the L0 servers are responding with 500 for the wallet icons. this is happening in prod too, it is not related to this PR

## Test scenarios
- on mobile, install and sign into metamask, coinbase, and phantom apps
- on mobile, go to https://deploy-preview-21--telos-bridge.netlify.app/
- tap "Connect"
    - you should see "Continue on...." + Metamask, coinbase, and phantom
- tap Metamask
    - metamask should open to the bridge application
- go back to bridge in the browser and tap Coinbase
    - coinbase should open to the bridge application
- go back to bridge in the browser and tap phantom
    - the phantom app should open (just to the homepage - dapp deeplinking is not supported)
- on desktop, functionality should be the same as on https://bridge.telos.net

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
