### PR TITLE
fix: set telos default extra gas on destination

### DIFF
--- a/src/features/core/stores/airdropStore.tsx
+++ b/src/features/core/stores/airdropStore.tsx
@@ -1,5 +1,5 @@
 import {ChainId} from '@layerzerolabs/lz-sdk';
-import {CurrencyAmount, DefaultAirdropProvider} from '@layerzerolabs/ui-core';
+import {Currency, CurrencyAmount, DefaultAirdropProvider, getNativeCurrency} from '@layerzerolabs/ui-core';
 import assert from 'assert';
 import {flow, makeAutoObservable, ObservableMap} from 'mobx';
 
@@ -10,7 +10,17 @@ export class AirdropStore {
     makeAutoObservable(this, {}, {autoBind: true});
   }
   getDefault(dstChainId: ChainId): CurrencyAmount | undefined {
-    return this.defaultAmount.get(String(dstChainId));
+    const defaultGasOnDst = this.defaultAmount.get(String(dstChainId));
+ 
+    // set default gas on destination value to .05 TLOS (max allowed) if unset
+    if (defaultGasOnDst?.numerator.toString() === '0' && dstChainId === ChainId.TELOS){
+      const dstNativeCurrency = getNativeCurrency(ChainId.TELOS);
+      const defaultAmount = CurrencyAmount.fromRawAmount(dstNativeCurrency as Currency, 50000000000000000); 
+      this.defaultAmount.set(String(ChainId.TELOS), defaultAmount);
+      return defaultAmount;
+    }
+ 
+    return defaultGasOnDst;
   }
   addProviders(providers: DefaultAirdropProvider[]) {
     this.providers.push(...providers);

--- a/src/features/core/stores/airdropStore.tsx
+++ b/src/features/core/stores/airdropStore.tsx
@@ -15,7 +15,7 @@ export class AirdropStore {
     // set default gas on destination value to .05 TLOS (max allowed) if unset
     if (defaultGasOnDst?.numerator.toString() === '0' && dstChainId === ChainId.TELOS){
       const dstNativeCurrency = getNativeCurrency(ChainId.TELOS);
-      const defaultAmount = CurrencyAmount.fromRawAmount(dstNativeCurrency as Currency, 50000000000000000); 
+      const defaultAmount = CurrencyAmount.fromRawAmount(dstNativeCurrency, 50000000000000000); 
       this.defaultAmount.set(String(ChainId.TELOS), defaultAmount);
       return defaultAmount;
     }


### PR DESCRIPTION
# Fixes #52 

## Description
sets default gas when Telos is destination network to .05 TLOS (current max value)
## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code


