### PR TITLE
fix: set network selection list order

### DIFF
--- a/src/features/bridge/stores/bridgeStore.tsx
+++ b/src/features/bridge/stores/bridgeStore.tsx
@@ -101,6 +101,12 @@ export class BridgeStore {
     );
   }
 
+  static sortChains(chains: ChainId[]): ChainId[] {
+    // desired order of network selection list
+    const chainOrder = [ChainId.TELOS, ChainId.ETHEREUM, ChainId.POLYGON, ChainId.BSC, ChainId.ZKSYNC, ChainId.ZKCONSENSYS, ChainId.AVALANCHE,  ChainId.ARBITRUM];
+    return chains.sort((a,b) => chainOrder.indexOf(b) - chainOrder.indexOf(a));
+  }
+
   // views
   get output(): BridgeOutput | undefined {
     return fromPromiseValue(this.promise.output);
@@ -144,7 +150,8 @@ export class BridgeStore {
   }
 
   get chains(): ChainId[] {
-    return Array.from(new Set(this.currencies.map((c) => c.chainId)));
+    const chainList = Array.from(new Set(this.currencies.map((c) => c.chainId)));
+    return BridgeStore.sortChains(chainList);
   }
 
   get srcCurrencyOptions(): CurrencyOption[] {
@@ -219,7 +226,9 @@ export class BridgeStore {
   }
 
   get srcNetworkOptions(): ChainOption[] {
-    const chains = Array.from(new Set(this.srcCurrencyOptions.map((c) => c.currency.chainId)));
+    const chainList = Array.from(new Set(this.srcCurrencyOptions.map((c) => c.currency.chainId)));
+    const chains = BridgeStore.sortChains(chainList);
+
     return chains.map((chainId) => ({
       chainId,
       disabled: false,

--- a/src/features/bridge/stores/bridgeStore.tsx
+++ b/src/features/bridge/stores/bridgeStore.tsx
@@ -101,10 +101,11 @@ export class BridgeStore {
     );
   }
 
+  // preferred order of network selection list
+  static chainOrder = [ChainId.TELOS, ChainId.ETHEREUM, ChainId.BSC, ChainId.POLYGON, ChainId.ZKSYNC, ChainId.ZKCONSENSYS, ChainId.AVALANCHE,  ChainId.ARBITRUM];
+
   static sortChains(chains: ChainId[]): ChainId[] {
-    // desired order of network selection list
-    const chainOrder = [ChainId.TELOS, ChainId.ETHEREUM, ChainId.POLYGON, ChainId.BSC, ChainId.ZKSYNC, ChainId.ZKCONSENSYS, ChainId.AVALANCHE,  ChainId.ARBITRUM];
-    return chains.sort((a,b) => chainOrder.indexOf(b) - chainOrder.indexOf(a));
+    return chains.sort((a,b) => this.chainOrder.indexOf(b) - this.chainOrder.indexOf(a));
   }
 
   // views

--- a/src/features/bridge/ui/NetworkSelect.tsx
+++ b/src/features/bridge/ui/NetworkSelect.tsx
@@ -10,6 +10,7 @@ import {NetworkIcon} from '@/core/ui/NetworkIcon';
 import {SearchBar} from '@/core/ui/SearchBar';
 import {SelectButton} from '@/core/ui/SelectButton';
 import {SxProps, Theme} from '@/core/ui/system';
+import { BridgeStore } from '../stores/bridgeStore';
 
 interface CommonProps {
   theme?: Theme;
@@ -55,13 +56,13 @@ export const NetworkSelect: React.FC<NetworkSelectProps> = observer(
     const modal = useToggle();
     const [search, setSearch] = useState('');
     const filtered = options.map(toOption).filter((option) => matchSearch(option.chainId, search));
+    
+    // maintain preferred order while filtering available options to the top
+    filtered.sort((a, b) => BridgeStore.chainOrder.indexOf(a.chainId) - BridgeStore.chainOrder.indexOf(b.chainId))
+    filtered.sort((a, b) => (a.disabled === b.disabled) || (a.disabled && !b.disabled) ? 1 : -1);
 
     const icon = withIcon ? <NetworkIcon chainId={value} size={40} /> : null;
     const network = value ? getNetwork(value) : undefined;
-
-    const sorted = filtered.sort((a) => {
-      return a.disabled ? 1 : -1;
-    });
 
     function close() {
       modal.close();
@@ -92,7 +93,7 @@ export const NetworkSelect: React.FC<NetworkSelectProps> = observer(
           open={readonly ? false : modal.value}
           onClose={close}
         >
-          {sorted.map((option, index) => {
+          {filtered.map((option, index) => {
             const {chainId} = option;
             const network = getNetwork(chainId);
             const onClick = () => {


### PR DESCRIPTION
## Description
Specifies and sets order of network listing in selection dropdown with Telos first

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
