### PR TITLE
clear up gas modal text

### DIFF
--- a/src/features/bridge/ui/GasOnDestinationModal.tsx
+++ b/src/features/bridge/ui/GasOnDestinationModal.tsx
@@ -50,10 +50,9 @@ export const GasOnDestinationModal = observer((props: GasOnDestinationModalProps
           <Box component='span' color='primary.main'>
             {dstNative?.symbol}
           </Box>{' '}
-          you want to swap.
+          you want to receive at the destination.
           <br />
-          The total amount you’ll pay in your wallet includes the gas you’ll be airdropping to your
-          destination.
+          The total amount you'll pay in your wallet includes the gas you'll be airdropping.
         </Box>
         <Box sx={{mt: 4, mb: 2}}>
           <Selector selection={form.dstNativeAmount}>


### PR DESCRIPTION
Modify gas text to make it clear to users what is happening when they are choosing an amount of gas to purchase for the destination chain.