### PR TITLE
#101 | Fix bridge token allowance process

### DIFF
--- a/src/features/bridge/ui/Alerts.tsx
+++ b/src/features/bridge/ui/Alerts.tsx
@@ -22,12 +22,12 @@ export const Alerts = observer(() => {
             : bridgeStore.isRegistering
             ? 'Register token first'
             : bridgeStore.isResetting
-            ? 'Resetting approvals'
+            ? 'Setting Allowance'
             : bridgeStore.isApproving
-            ? 'Approving transaction'
+            ? 'Awaiting Allowance Confirmation'
             : bridgeStore.isMining
             ? 'Submitting transaction'
-            : 'Confirm in your wallet'
+            : 'Confirm Bridge Transaction'
         }
       >
         <div>

--- a/src/features/bridge/ui/Alerts.tsx
+++ b/src/features/bridge/ui/Alerts.tsx
@@ -21,6 +21,8 @@ export const Alerts = observer(() => {
             ? 'Switch chain'
             : bridgeStore.isRegistering
             ? 'Register token first'
+            : bridgeStore.isResetting
+            ? 'Resetting approvals'
             : bridgeStore.isApproving
             ? 'Approving transaction'
             : bridgeStore.isMining
@@ -50,6 +52,8 @@ export const Alerts = observer(() => {
             'Please check pending wallet actions if you did not receive a transaction prompt.'
           ) : bridgeStore.isRegistering ? (
             'Confirm this transaction in your wallet'
+          ) : bridgeStore.isResetting ? (
+            'First approve this reset transaction in your wallet.'
           ) : bridgeStore.isApproving ? (
             'Approve this transaction in your wallet.'
           ) : bridgeStore.isSigning ? (


### PR DESCRIPTION
# Fixes #101

## Description
This PR includes a fix for the problem of not getting the gas estimation right for the approvals before the actual transaction. 
- First, it updates the internal state before deciding if it's even needed to modify the current approval.
- Only if the current approval is not enough for the desired amount, it will trigger a reset transaction (setting the approvals to zero), and immediately after that, it triggers the normally `approve` transaction with the exact amount entered by the user.

These changes did not require the library to be modified.

## Test scenarios
You gotta have at least 5 USTD in the Ethereum chain and some ETH to pay the fees.
- go to [USDT contract code on etherscan](https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7#readContract).
  - Here you can check your current approval state. To do that, use the `allowed` read function using your address as the first argument and the bridge contract (0x9c5ebCbE531aA81bD82013aBF97401f5C6111d76) as the second.
  - If you need to change the approval, go to the write tab, and use the `approve` function with the contract address as the spender and the value with the amount desired (enter `1000000` for 1USDT)

- select USDT from the Ethereum blockchain as the origin
- select Telos EVM as the destination
- play with different values and check all of them pass throw with no errors

Cases are:
1 - you have **More approval than you are willing to transfer**. Best case: you don't need to approve anything.
2 - you cave **0 approval**. Normal case: This will cause you to only approve the Transaction without resetting anything.
3 - you have **some but not enough approval**. Rarest case: This will trigger the reset and then the exact approval you need.

## Screenshots
[telos-bridge--resetting-approvals.webm](https://github.com/telosnetwork/telos-bridge/assets/4420760/fbba2339-1aef-455f-b687-bc70e7ed8f7b)

